### PR TITLE
Issue: #12] HTMLでのエラー表示

### DIFF
--- a/script.js
+++ b/script.js
@@ -20,11 +20,18 @@ async function fetchADOP() {
         const apod = json.apod;
         const apodContainer = document.getElementById('apod-container');
 
-        apodContainer.innerHTML = `
+        if (apod.title === '') {
+            apodContainer.innerHTML = `
+                <p style="color: red;">エラー: APODデータが存在しません。日付を確認してください。</p>
+            `;
+        } else {
+            apodContainer.innerHTML = `
             <h2>${apod.title}</h2>
             <img src="${apod.hdurl}" alt="${apod.title}">
             <p>${apod.explanation}</p>
         `;
+        }
+        
     } catch (error) {
         console.error(error.message);
     }


### PR DESCRIPTION



## 概要

日付エラーをHTMLで表示するフロントエンドの作成

## 変更内容

- script.jsにコードを追加
  - apod.titleが空のときにエラー文をHTMLで表示するコードを追加

## テスト結果

![スクリーンショット 2024-10-21 185414](https://github.com/user-attachments/assets/4d2d5fb6-a21c-4e2c-b726-45af800271ac)


## レビューポイント
<!-- レビュアーに特に見てほしい点があれば記述 -->

## 関連Issue

#12 